### PR TITLE
exit after usage

### DIFF
--- a/bqlmon.c
+++ b/bqlmon.c
@@ -440,6 +440,7 @@ int main(int argc, char **argv)
 			break;
 		default:
 			usage(argv[0]);
+			exit(EXIT_SUCCESS);
 			break;
 		}
 	}


### PR DESCRIPTION
Currently -h will not terminate the program. It shows the usage dialog
but spawn the curses "gui". This is not what user expect if calling
bqlmon -h

Signed-off-by: Hagen Paul Pfeifer hagen@jauu.net
