### PR TITLE
doc: fix sysfs directory in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ context, but that interrupt never fires, we will quickly queue up many buffers
 that are not freed.
 
 BQL exposes a few sysfs attributes in
-/sys/class/net/*interface*/tx-*queue*/byte_queue_limits which are per-queue
+/sys/class/net/*interface*/queues/tx-*N*/byte_queue_limits/ which are per-queue
 information about:
 
 - in-flight packets


### PR DESCRIPTION
The README documentation were pointing to the wrong
directory for byte_queue_limits stats, fix that.

Signed-off-by: Jesper Dangaard Brouer brouer@redhat.com
